### PR TITLE
docs: Fix a few typos

### DIFF
--- a/contrib/llvm-project/llvm/tools/llvm-objcopy/wasm/WasmObjcopy.cpp
+++ b/contrib/llvm-project/llvm/tools/llvm-objcopy/wasm/WasmObjcopy.cpp
@@ -91,7 +91,7 @@ static void removeSections(const CommonConfig &Config, Object &Obj) {
   if (!Config.OnlySection.empty()) {
     RemovePred = [&Config](const Section &Sec) {
       // Explicitly keep these sections regardless of previous removes.
-      // Remove everything else, inluding known sections.
+      // Remove everything else, including known sections.
       return !Config.OnlySection.matches(Sec.Name);
     };
   }

--- a/contrib/ntp/ntpd/refclock_datum.c
+++ b/contrib/ntp/ntpd/refclock_datum.c
@@ -276,7 +276,7 @@ datum_pts_start(
 	arg.c_cflag = B9600 | CS8 | CREAD | PARENB | CLOCAL;
 	arg.c_lflag = 0;
 	arg.c_cc[VMIN] = 0;		/* start timeout timer right away (not used) */
-	arg.c_cc[VTIME] = 30;		/* 3 second timout on reads (not used) */
+	arg.c_cc[VTIME] = 30;		/* 3 second timeout on reads (not used) */
 
 	rc = tcsetattr(datum_pts->PTS_fd, TCSANOW, &arg);
 	if (rc < 0) {

--- a/contrib/ntp/ntpq/ntpq.c
+++ b/contrib/ntp/ntpq/ntpq.c
@@ -1252,7 +1252,7 @@ getresponse(
 
 		/*
 		 * Copy the data into the data buffer, and bump the
-		 * timout base in case we need more.
+		 * timeout base in case we need more.
 		 */
 		memcpy((char *)pktdata + offset, &rpkt.u, count);
 		tobase = (uint32_t)time(NULL);

--- a/contrib/telnet/telnetd/sys_term.c
+++ b/contrib/telnet/telnetd/sys_term.c
@@ -792,7 +792,7 @@ getptyslave(void)
 # endif
 	extern int def_tspeed, def_rspeed;
 	/*
-	 * Opening the slave side may cause initilization of the
+	 * Opening the slave side may cause initialization of the
 	 * kernel tty structure.  We need remember the state of
 	 * 	if linemode was turned on
 	 *	terminal window size

--- a/crypto/heimdal/appl/telnet/telnetd/sys_term.c
+++ b/crypto/heimdal/appl/telnet/telnetd/sys_term.c
@@ -816,7 +816,7 @@ void getptyslave(void)
 
     struct winsize ws;
     /*
-     * Opening the slave side may cause initilization of the
+     * Opening the slave side may cause initialization of the
      * kernel tty structure.  We need remember the state of
      * 	if linemode was turned on
      *	terminal window size

--- a/sys/contrib/alpine-hal/al_hal_udma_config.h
+++ b/sys/contrib/alpine-hal/al_hal_udma_config.h
@@ -216,7 +216,7 @@ struct al_udma_s2m_completion_conf {
 
 	uint16_t comp_fifo_depth;	/* Size of completion fifo in words */
 	uint16_t unack_fifo_depth;	/* Size of unacked fifo in descs */
-	uint32_t timeout;		/* Ack timout from stream interface */
+	uint32_t timeout;		/* Ack timeout from stream interface */
 };
 
 /** M2S UDMA DWRR configuration */

--- a/sys/dev/irdma/irdma_pble.c
+++ b/sys/dev/irdma/irdma_pble.c
@@ -240,7 +240,7 @@ irdma_get_type(struct irdma_sc_dev *dev,
 }
 
 /**
- * add_pble_prm - add a sd entry for pble resoure
+ * add_pble_prm - add a sd entry for pble resource
  * @pble_rsrc: pble resource management
  */
 static int

--- a/sys/dev/mlx4/mlx4_ib/mlx4_ib_mcg.c
+++ b/sys/dev/mlx4/mlx4_ib/mlx4_ib_mcg.c
@@ -433,7 +433,7 @@ static u16 cmp_rec(struct ib_sa_mcmember_data *src,
 }
 
 /* release group, return 1 if this was last release and group is destroyed
- * timout work is canceled sync */
+ * timeout work is canceled sync */
 static int release_group(struct mcast_group *group, int from_timeout_handler)
 {
 	struct mlx4_ib_demux_ctx *ctx = group->demux;

--- a/sys/dev/mpr/mpr_mapping.c
+++ b/sys/dev/mpr/mpr_mapping.c
@@ -2553,7 +2553,7 @@ mpr_mapping_check_devices(void *data)
  * mpr_mapping_initialize - initialize mapping tables
  * @sc: per adapter object
  *
- * Read controller persitant mapping tables into internal data area.
+ * Read controller persistent mapping tables into internal data area.
  *
  * Return 0 for success or non-zero for failure.
  */

--- a/sys/dev/mps/mps_mapping.c
+++ b/sys/dev/mps/mps_mapping.c
@@ -2084,7 +2084,7 @@ mps_mapping_check_devices(void *data)
  * mps_mapping_initialize - initialize mapping tables
  * @sc: per adapter object
  *
- * Read controller persitant mapping tables into internal data area.
+ * Read controller persistent mapping tables into internal data area.
  *
  * Return 0 for success or non-zero for failure.
  */

--- a/sys/dev/pms/RefTisa/tisa/sassata/common/tdioctl.c
+++ b/sys/dev/pms/RefTisa/tisa/sassata/common/tdioctl.c
@@ -1117,7 +1117,7 @@ tdsaGpioSetup(
 
   osIoctlTimer = &tdsaAllShared->osIoctlTimer;
   tdsaInitTimerRequest(tiRoot, osIoctlTimer);
-  tdIoctlStartTimer(tiRoot, osIoctlTimer); /* Start the timout handler for both ioctl and controller response */
+  tdIoctlStartTimer(tiRoot, osIoctlTimer); /* Start the timeout handler for both ioctl and controller response */
   tdsaAllShared->tdFWControlEx.virtAddr = (bit8 *)osIoctlTimer;
 
   tdsaAllShared->tdFWControlEx.usrAddr = (bit8 *)&agIOCTLPayload->FunctionSpecificArea[0];

--- a/sys/dev/pms/RefTisa/tisa/sassata/common/tdsatypes.h
+++ b/sys/dev/pms/RefTisa/tisa/sassata/common/tdsatypes.h
@@ -220,7 +220,7 @@ typedef struct tdsaContext_s {
   agsaHwConfig_t        HwConfig;
 
 
-  /**< Copy of TI low level resoure */
+  /**< Copy of TI low level resource */
   tiLoLevelResource_t   loResource;
 
   /* information of ESGL pages allocated

--- a/sys/kern/kern_descrip.c
+++ b/sys/kern/kern_descrip.c
@@ -1293,7 +1293,7 @@ closefp_impl(struct filedesc *fdp, int fd, struct file *fp, struct thread *td,
 	 * We now hold the fp reference that used to be owned by the
 	 * descriptor array.  We have to unlock the FILEDESC *AFTER*
 	 * knote_fdclose to prevent a race of the fd getting opened, a knote
-	 * added, and deleteing a knote for the new fd.
+	 * added, and deleting a knote for the new fd.
 	 */
 	if (__predict_false(!TAILQ_EMPTY(&fdp->fd_kqlist)))
 		knote_fdclose(td, fd);

--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -1461,7 +1461,7 @@ main(int argc, char *argv[])
 	sci_init(ctx);
 
 	/*
-	 * Exit if a device emulation finds an error in its initilization
+	 * Exit if a device emulation finds an error in its initialization
 	 */
 	if (init_pci(ctx) != 0) {
 		perror("device emulation initialization error");


### PR DESCRIPTION
There are small typos in:
- contrib/llvm-project/llvm/tools/llvm-objcopy/wasm/WasmObjcopy.cpp
- contrib/ntp/ntpd/refclock_datum.c
- contrib/ntp/ntpq/ntpq.c
- contrib/telnet/telnetd/sys_term.c
- crypto/heimdal/appl/telnet/telnetd/sys_term.c
- sys/contrib/alpine-hal/al_hal_udma_config.h
- sys/dev/irdma/irdma_pble.c
- sys/dev/mlx4/mlx4_ib/mlx4_ib_mcg.c
- sys/dev/mpr/mpr_mapping.c
- sys/dev/mps/mps_mapping.c
- sys/dev/pms/RefTisa/tisa/sassata/common/tdioctl.c
- sys/dev/pms/RefTisa/tisa/sassata/common/tdsatypes.h
- sys/kern/kern_descrip.c
- usr.sbin/bhyve/bhyverun.c

Fixes:
- Should read `timeout` rather than `timout`.
- Should read `initialization` rather than `initilization`.
- Should read `resource` rather than `resoure`.
- Should read `persistent` rather than `persitant`.
- Should read `including` rather than `inluding`.
- Should read `deleting` rather than `deleteing`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md