### PR TITLE
fix libobjc2 dependency on mig (migcom)

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -2331,6 +2331,8 @@ _yacc=		usr.bin/yacc
 _gensnmptree=	usr.sbin/bsnmpd/gensnmptree
 .endif
 
+_migcom=	usr.bin/migcom
+gnu/lib/libobjc2__L: usr.bin/migcom__L
 
 # We need to build tblgen when we're building clang or lld, either as
 # bootstrap tools, or as the part of the normal build.
@@ -2524,6 +2526,7 @@ bootstrap-tools: ${_bt}-links .PHONY
     ${_localedef} \
     ${_mkcsmapper} \
     ${_mkesdb} \
+    ${_migcom} \
     ${LOCAL_BSTOOL_DIRS}
 ${_bt}-${_tool}: ${_bt}-links .PHONY .MAKE
 	${_+_}@${ECHODIR} "===> ${_tool} (obj,all,install)"; \

--- a/usr.bin/migcom/mig.sh
+++ b/usr.bin/migcom/mig.sh
@@ -31,6 +31,11 @@ MIGCOM="/usr/bin/migcom"	# -migcom <path>
 # valid.
 SYSROOT=$(expr $(dirname $0) : "\(.*\)/usr/bin") || SYSROOT=""
 
+if [ ! -x "$MIGCOM" ]; then
+    _mydir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+    MIGCOM="${_mydir}/migcom"
+fi
+
 while [ $# -gt 1 ]
 do
     case "$1" in


### PR DESCRIPTION
* adds migcom to the bootstrap list and to libobjc2's dependencies
* fix running mig wrapper before migcom is installed to /usr/bin during bootstrap