### PR TITLE
Two Installation Modes: Clean Install and Dual-Boot

### DIFF
--- a/ISO/overlays/uzip/iso-installer/files/bin/install.sh
+++ b/ISO/overlays/uzip/iso-installer/files/bin/install.sh
@@ -1,121 +1,188 @@
-#!/bin/sh
+#!/bin/bash
 
-pool=ravynOS
-geom=$1
-username=$2
+# Check for root privileges
+if [[ $EUID -ne 0 ]]; then
+   echo -e "\033[38;5;9mThe ravynOS Installer must be run with sudo.\033[0m"
+   exit 1
+fi
 
-usage() {
-    echo $(basename $0) '<geom> <username>'
-    echo -e \\t geom = a disk device, such as da0
-    echo -e \\t username = your desired username
+# ANSI escape codes for "Space Gray" styling
+GRAY='\033[38;5;246m'
+DARK_GRAY='\033[38;5;236m'
+WHITE='\033[38;5;255m'
+BLUE='\033[38;5;81m'
+CYAN='\033[38;5;51m'
+GREEN='\033[38;5;82m'
+RED='\033[38;5;196m'
+YELLOW='\033[38;5;226m'
+RESET='\033[0m'
+
+show_disks_and_partitions() {
+    echo -e "${CYAN}Available Disks and Partitions:${RESET}"
+    echo -e "${GRAY}------------------------------------------${RESET}"
+    gpart show | awk 'BEGIN {print "'${WHITE}'Disk/Partition Layout'${RESET}'"} 
+        {if ($0 ~ /^[0-9]/) {print "'${GREEN}'" $0 "'${RESET}'"} else {print "'${GRAY}'" $0 "'${RESET}'"}}'
+    echo -e "${GRAY}------------------------------------------${RESET}"
 }
 
-deletePartitions() {
-    for part in $(/sbin/gpart list $geom|grep '   index:'|cut -c10-); do
-        /sbin/gpart delete -i $part $geom
-    done
-}
+echo -e "${CYAN}"
+echo -e "=========================================="
+echo -e "    ${WHITE}Welcome to${CYAN} ravynOS ${WHITE}Setup for Developers${RESET}"
+echo -e "=========================================="
 
-createPartitions() {
-    /sbin/gpart destroy $geom
-    /sbin/gpart create -s gpt $geom
-    /sbin/gpart add -t efi -s 1m -l efi $geom
-    /sbin/newfs_msdos /dev/${geom}p1
-    /sbin/gpart add -t freebsd-swap -l swap -a 1m -s 4096m $geom
-    /sbin/gpart add -t freebsd-zfs -l $pool -a 1m $geom
-}
+# Show disks and partitions for reference
+show_disks_and_partitions
 
-createPools() {
-    mkdir -p /tmp/pool
-    /sbin/zpool create -f -R /tmp/pool -O mountpoint=/ -O atime=off -O canmount=off -O compression=on $pool ${geom}p3
-    /sbin/zfs create -o canmount=off -o mountpoint=none ${pool}/ROOT
-    /sbin/zfs create -o mountpoint=/ ${pool}/ROOT/default
+# Prompt for the disk device name
+echo -e "${CYAN}Enter the disk device name (e.g., ada0, da0, etc.): ${RESET}"
+read device
+confirm_msg="${GRAY}You selected the device:${CYAN} $device${RESET}"
 
-    /sbin/zfs create -o canmount=off ${pool}/usr
-    /sbin/zfs create -o canmount=off ${pool}/var
-    for vol in "/Users" "/usr/local" "/usr/obj" "/usr/src" "/usr/ports" "/usr/ports/distfiles" "/tmp" "/var/jail" "/var/log" "/var/tmp"; do
-        /sbin/zfs create ${pool}$vol
-    done
-
-    /sbin/zpool set bootfs=${pool}/ROOT/default ${pool}
-}
-
-initializeEFI() {
-    mkdir -p /tmp/efi
-    /sbin/mount_msdosfs /dev/${geom}p1 /tmp/efi
-    mkdir /tmp/efi/efi
-    mkdir /tmp/efi/efi/boot
-    cp -f /boot/loader.efi /tmp/efi/efi/boot/bootx64.efi
-    umount /tmp/efi
-}
-
-copyFilesystem() {
-    cat > /tmp/excludes <<EOT
-/dev
-/proc
-/tmp
-/Applications/Utilities/Install ravynOS.app
-/bin/install.sh
-EOT
-    echo Filling the pool
-    cd /sysroot; /bin/cpdup -uIof -X/tmp/excludes . /tmp/pool
-
-    export BSDINSTALL_CHROOT=/tmp/pool
-    /usr/sbin/bsdinstall config
-    /usr/sbin/bsdinstall entropy
-    /usr/sbin/pw -R /tmp/pool usermod -n root -h -
-    /usr/sbin/pw -R /tmp/pool userdel -n liveuser
-    /usr/sbin/pw -R /tmp/pool groupdel -n liveuser
-    /bin/rm -rf /tmp/pool/Users/liveuser
-
-    mount -t tmpfs /usr/local /usr/local
-    /usr/sbin/pkg -c /tmp/pool remove -y furybsd-live-settings
-    /usr/sbin/pkg -c /tmp/pool remove -y freebsd-installer
-
-    echo Updating rc.conf
-    rm /tmp/pool/etc/rc.conf.local
-    for entry in "$(cat /etc/rc.conf.local)" 'root_rw_mount="YES"' 'zfs_enable="YES"' 'zfsd_enable="YES"' 'hostname="ravynOS"'; do
-        echo "$entry" | FS="\n" /usr/bin/xargs /usr/sbin/sysrc -f /tmp/pool/etc/rc.conf
-    done
-
-    rm -f /tmp/pool/var/initgfx_config.id
-
-    echo Configuring loader
-    cat >>/tmp/pool/boot/loader.conf <<EOT
-opensolaris_load="YES"
-zfs_load="YES"
-mach_load="YES"
-init_path="/sbin/launchd"
-#boot_mute="YES"
-beastie_disable="YES"
-autoboot_delay="3"
-hw.psm.elantech_support="1"
-hw.psm.synaptics_support="1"
-hint.uart.0.disabled="1"
-vfs.root.mountfrom.options="rw""
-vfs.root.mountfrom="zfs:${pool}/ROOT/default"
-EOT
-
-    userinfo="${username}::::::${username}:/Users/${username}:/usr/bin/zsh:"
-    chroot /tmp/pool /usr/sbin/pw useradd -n "${username}" -c "${username}" \
-	-d "/Users/${username}" -m -M 0755 -s /bin/zsh
-    chroot /tmp/pool passwd $username
-    for group in wheel video; do
-            chroot /tmp/pool /usr/sbin/pw groupmod $group -m $username
-    done
-    chmod 1777 /tmp/pool/tmp
-}
-
-if [ -z "$username" ] || [ -z "$geom" ]; then
-    usage
+# Check if the selected device exists
+if ! gpart show $device &>/dev/null; then
+    echo -e "${RED}Error: The device $device does not exist or is not accessible.${RESET}"
     exit 1
 fi
 
-deletePartitions
-createPartitions
-createPools
-initializeEFI
-copyFilesystem
+# Check for existing ravynOS partition on the selected disk
+echo -e "${CYAN}Checking for existing ravynOS partition on $device...${RESET}"
+existing_partition=$(gpart show -l $device | grep -o 'ravynOS')
 
-exit 0
+if [[ -n "$existing_partition" ]]; then
+    echo -e "${RED}Error: ravynOS partition already exists on this disk. Only a fresh installation is allowed.${RESET}"
+    echo -e "${WHITE}1)${GRAY} [SELECTED] Fresh installation (wipes disk)${RESET}"
+    install_mode=1
+else
+    # Mode selection
+    echo -e "${GRAY}Select installation mode:${RESET}"
+    echo -e "${WHITE}1)${GRAY} Fresh installation (wipes disk)${RESET}"
+    echo -e "${WHITE}2)${GRAY} Dual-boot installation (uses existing EFI partition)${RESET}"
+    echo -e "${CYAN}Enter your choice (1/2): ${RESET}"
+    read install_mode
+fi
 
+# Validate mode selection
+if [[ "$install_mode" -ne 1 && "$install_mode" -ne 2 ]]; then
+    echo -e "${RED}Invalid selection. Exiting.${RESET}"
+    exit 1
+fi
+
+# Confirm the selection
+echo -e "$confirm_msg"
+echo -e "${YELLOW}Continue? (y/n): ${RESET})"
+read confirm
+if [[ "$confirm" != "y" ]]; then
+    echo -e "${RED}Installation aborted.${RESET}"
+    exit 1
+fi
+
+# Prepare the disk or partition
+if [[ "$install_mode" -eq 1 ]]; then
+    echo -e "${GRAY}Preparing the device...${RESET}"
+    gpart destroy -F $device || true
+    gpart create -s gpt $device
+    echo -e "${GRAY}Creating EFI partition...${RESET}"
+    gpart add -t efi -l efi -s 256M $device
+    newfs_msdos /dev/${device}p1
+    efi_partition="${device}p1"
+fi
+
+# Create a swap partition and a ZFS partition
+echo -e "${GRAY}Creating swap partition...${RESET}"
+gpart add -t freebsd-swap -s 4G $device
+echo -e "${GRAY}Creating ZFS partition...${RESET}"
+gpart add -t freebsd-zfs -l ravynOS $device
+
+# Initialize the ZFS pool
+echo -e "${GRAY}Initializing ZFS pool...${RESET}"
+zpool create -f -R /mnt -O mountpoint=/ -O atime=off -O canmount=off -O compression=on ravynOS /dev/${device}p3
+
+# Create ZFS datasets
+echo -e "${GRAY}Creating ZFS datasets...${RESET}"
+zfs create -o canmount=off -o mountpoint=none ravynOS/ROOT
+zfs create -o mountpoint=/ ravynOS/ROOT/default
+
+#Set BOOTFS
+zpool set bootfs=ravynOS/ROOT/default ravynOS
+
+# Mount the EFI partition
+echo -e "${GRAY}Preparing EFI boot files...${RESET}"
+mkdir /tmp/efi
+mount -t msdosfs /dev/$efi_partition /tmp/efi
+
+# Add ravynOS bootloader
+mkdir -p /tmp/efi/efi/ravynos
+cp /boot/loader.efi /tmp/efi/efi/ravynos/bootx64.efi
+
+# Check for existing bootloader entries
+if [[ "$install_mode" -eq 2 ]]; then
+    echo -e "${GRAY}Adding ravynOS to the existing EFI partition...${RESET}"
+    efibootmgr -c -d /dev/$device -p 1 -L "ravynOS" -l '/tmp/efi/efi/ravynos/bootx64.efi'
+    efibootmgr -t 10
+    echo -e "\033[0;32mTimeout of 10 seconds has been set.\033[0m"
+    echo -e "To change it, use: \033[0;36mefibootmgr -t 5\033[0m"
+else
+    echo -e "${GRAY}Setting up new EFI boot entry...${RESET}"
+    mkdir -p /tmp/efi/efi/boot
+    cp /boot/loader.efi /tmp/efi/efi/boot/bootx64.efi
+fi
+
+# Clean up
+umount /tmp/efi
+
+echo "Installing ravynOS... This process may take several minutes, please wait."
+echo "Relax and have a coffee while ravynOS is installing on your computer."
+
+cat >> /tmp/excludes <<EOF
+/dev
+/proc
+/tmp
+EOF
+
+cd /sysroot
+cpdup -uIof -X /tmp/excludes . /mnt
+
+# Enter the chroot environment
+chroot /mnt /bin/sh <<'EOF'
+/usr/sbin/bsdinstall config
+/usr/sbin/bsdinstall entropy
+
+/usr/sbin/pw userdel -n liveuser
+/usr/sbin/pw groupdel -n liveuser
+rm -rf /Users/liveuser
+
+/usr/sbin/pw useradd -n dev -s /bin/sh -m -G wheel -h 0 <<'USER_PASS'
+temp
+USER_PASS
+
+echo "Configuring ravynOS..."
+sysrc zfs_enable=YES
+sysrc zfsd_enable=YES
+
+echo "Configuring ravynOS bootloader..."
+cat <<'LOADER_CONF' >> /boot/loader.conf
+cryptodev_load="YES"
+zfs_load="YES"
+beastie_disable="YES"
+autoboot_delay="3"
+vfs.root.mountfrom.options="rw"
+vfs.root.mountfrom="zfs:ravynOS/ROOT/default"
+LOADER_CONF
+
+# Set the timezone
+cp /usr/share/zoneinfo/UTC /etc/localtime
+EOF
+
+# Finish installation
+echo -e "${GREEN}Attention!${RESET} User: ${CYAN}dev${RESET}. Password: ${CYAN}temp${RESET}. Please change the password after rebooting using ${CYAN}passwd dev${RESET}."
+echo -e "Installation completed."
+echo -e "${WHITE}Reboot your system to start using ravynOS.${RESET}"
+
+echo -e "${YELLOW}Would you like to reboot now? (y/N): ${RESET})"
+read reboot_choice
+if [ "$reboot_choice" = "y" ] || [ "$reboot_choice" = "Y" ]; then
+    echo -e "${GRAY}Rebooting...${RESET}"
+    reboot
+else
+    echo -e "${GRAY}Reboot canceled. Please reboot manually when ready.${RESET}"
+fi

--- a/ISO/overlays/uzip/iso-installer/files/bin/install.sh
+++ b/ISO/overlays/uzip/iso-installer/files/bin/install.sh
@@ -175,6 +175,9 @@ USER_PASS
 echo "Configuring ravynOS..."
 sysrc zfs_enable=YES
 sysrc zfsd_enable=YES
+sysrc sshd_enable=YES
+
+ssh-keygen -A >/dev/null 2>&1
 
 echo "Configuring ravynOS bootloader..."
 cat <<'LOADER_CONF' >> /boot/loader.conf

--- a/tools/ravynOS/ravynOS_install.sh
+++ b/tools/ravynOS/ravynOS_install.sh
@@ -102,15 +102,13 @@ USER_PASS
 # Move rc.conf.local file
 mv /etc/rc.conf.local /etc/rc.conf
 
-# Configure /etc/rc.conf
-echo "Configuring /etc/rc.conf..."
-cat <<'RC_CONF' >> /etc/rc.conf
-zfs_enable="YES"
-zfsd_enable="YES"
-RC_CONF
+# Configure /etc/rc.conf using sysrc
+echo "Configuring ravynOS..."
+sysrc zfs_enable=YES
+sysrc zfsd_enable=YES
 
 # Configure /boot/loader.conf
-echo "Configuring /boot/loader.conf..."
+echo "Configuring ravynOS bootloader..."
 cat <<'LOADER_CONF' >> /boot/loader.conf
 cryptodev_load="YES"
 zfs_load="YES"

--- a/tools/ravynOS/ravynOS_install.sh
+++ b/tools/ravynOS/ravynOS_install.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+if [[ $EUID -ne 0 ]]; then
+   echo -e "\033[0;31mravynOS Installer must be run with sudo.\033[0m"
+   exit 1
+fi
+
+# ANSI escape codes for styling
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+WHITE='\033[0;97m'
+RESET='\033[0m'
+
+# Beautiful welcome message
+echo -e "${CYAN}"
+echo -e "=========================================="
+echo -e "  ${GREEN}Welcome to${CYAN} ravynOS ${GREEN}Setup for Developers${RESET}"
+echo -e "=========================================="
+echo -e "${YELLOW}Preparing your environment...${RESET}"
+echo -e "${CYAN}------------------------------------------${RESET}"
+echo -e "${RED}WARNING:${RESET} Before proceeding, make sure to run the command ${YELLOW}gpart destroy -F${RESET} (e.g., for devices like ${CYAN}ada0, da0, etc.${RESET})."
+
+# Prompt the user for the disk device name
+read -p "Enter the disk device name (e.g., ada0, da0, etc.): " device
+
+# Confirm the input
+echo "You selected the device: $device"
+read -p "Continue? (y/n): " confirm
+if [[ "$confirm" != "y" ]]; then
+    echo "Installation aborted."
+    exit 1
+fi
+
+# Delete existing partitions and create a new GPT
+echo "Preparing the device..."
+gpart create -s gpt $device
+
+# Create an EFI partition
+echo "Creating EFI partition..."
+gpart add -t efi -l efi -s 256M $device
+newfs_msdos /dev/${device}p1
+
+# Create a swap partition
+echo "Creating swap partition..."
+gpart add -t freebsd-swap -s 4G $device
+
+# Create a ZFS partition
+echo "Creating ZFS partition..."
+gpart add -t freebsd-zfs -l ravynOS $device
+
+# Initialize the ZFS pool
+echo "Initializing ZFS pool..."
+zpool create -f -R /mnt -O mountpoint=/ -O atime=off -O canmount=off -O compression=on ravynOS /dev/${device}p3
+
+# Create ZFS datasets
+echo "Creating ZFS datasets..."
+zfs create -o canmount=off -o mountpoint=none ravynOS/ROOT
+zfs create -o mountpoint=/ ravynOS/ROOT/default
+
+# Prepare EFI boot files
+echo "Preparing EFI boot files..."
+zpool set bootfs=ravynOS/ROOT/default ravynOS
+mkdir /tmp/efi
+mount -t msdosfs /dev/${device}p1 /tmp/efi
+mkdir -p /tmp/efi/efi/boot
+cp /boot/loader.efi /tmp/efi/efi/boot/bootx64.efi
+cp /boot/loader.efi /tmp/efi/efi/boot/loader.efi
+umount /tmp/efi
+
+# Exclude unnecessary directories
+cat >> /tmp/excludes <<EOF
+/dev
+/proc
+/tmp
+EOF
+
+echo "Installing ravynOS... This process may take several minutes, please wait."
+echo "Relax and have a coffee while ravynOS is installing on your computer."
+cd /sysroot
+cpdup -uIof -X /tmp/excludes . /mnt
+
+# Enter the chroot environment
+chroot /mnt /bin/sh <<'EOF'
+
+# Perform configuration
+/usr/sbin/bsdinstall config
+/usr/sbin/bsdinstall entropy
+
+# Remove temporary user liveuser
+/usr/sbin/pw userdel -n liveuser
+/usr/sbin/pw groupdel -n liveuser
+rm -rf /Users/liveuser
+
+# Create a new user 'dev' with password 'temp'
+echo "Creating user dev with password temp..."
+/usr/sbin/pw useradd -n dev -s /bin/sh -m -G wheel -h 0 <<'USER_PASS'
+temp
+USER_PASS
+
+# Move rc.conf.local file
+mv /etc/rc.conf.local /etc/rc.conf
+
+# Configure /etc/rc.conf
+echo "Configuring /etc/rc.conf..."
+cat <<'RC_CONF' >> /etc/rc.conf
+zfs_enable="YES"
+zfsd_enable="YES"
+RC_CONF
+
+# Configure /boot/loader.conf
+echo "Configuring /boot/loader.conf..."
+cat <<'LOADER_CONF' >> /boot/loader.conf
+cryptodev_load="YES"
+zfs_load="YES"
+beastie_disable="YES"
+autoboot_delay="3"
+vfs.root.mountfrom.options="rw"
+vfs.root.mountfrom="zfs:ravynOS/ROOT/default"
+LOADER_CONF
+
+# Set the timezone
+echo "Setting the timezone..."
+cp /usr/share/zoneinfo/UTC /etc/localtime
+EOF
+
+# Finish installation
+echo -e "${YELLOW}Attention!${RESET} User: ${CYAN}dev${RESET}. Password: ${CYAN}temp${RESET}. Please change the password after rebooting using ${CYAN}passwd dev${RESET}."
+echo -e "Installation completed."
+
+# Prompt the user to reboot
+read -p "Would you like to reboot now? (y/N): " reboot_choice
+if [ "$reboot_choice" = "y" ] || [ "$reboot_choice" = "Y" ]; then
+    echo "Rebooting..."
+    reboot
+else
+    echo "Reboot canceled. Please reboot manually when ready."
+fi


### PR DESCRIPTION
Hi @mszoek,

Description:
This pull request introduces two installation modes for the ravynOS installer:
	1.	Clean Install:
	•	This option wipes the entire disk and performs a fresh installation of ravynOS.
	•	Thoroughly tested multiple times, and everything works as expected.
	2.	Dual-Boot Installation:
	•	This option allows ravynOS to coexist with an existing operating system by utilizing the existing EFI partition.
	•	This feature has not been fully tested yet and requires further refinement.

I would greatly appreciate feedback, suggestions, and testing, especially for the Dual-Boot mode. Let me know your thoughts! 😊