### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/usr.sbin/bhyve/virtio.c
+++ b/usr.sbin/bhyve/virtio.c
@@ -478,6 +478,9 @@ vq_endchains(struct vqueue_info *vq, int used_all_avail)
 	uint16_t event_idx, new_idx, old_idx;
 	int intr;
 
+	if (!vq || !vq->used)
+		return;
+
 	/*
 	 * Interrupt generation: if we're using EVENT_IDX,
 	 * interrupt if we've crossed the event threshold.


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in vq_endchains() that was cloned from acrn-hypervisor but did not receive the security patch. The original issue was reported and fixed under https://github.com/projectacrn/acrn-hypervisor/commit/154fe59531c12b82e26d1b24b5531f5066d224f5.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2021-36143
https://github.com/projectacrn/acrn-hypervisor/commit/154fe59531c12b82e26d1b24b5531f5066d224f5
