### PR TITLE
Fix return value in +[NSDrawer visibleEdgeWithPreferredEdge:parentWindow:drawerWindow:]

### DIFF
--- a/Frameworks/AppKit/NSDrawer.subproj/NSDrawer.m
+++ b/Frameworks/AppKit/NSDrawer.subproj/NSDrawer.m
@@ -110,9 +110,9 @@ NSString * const NSDrawerDidCloseNotification = @"NSDrawerDidCloseNotification";
             if (NSMaxY(screenRect) - NSMaxY(parentRect) < drawerRect.size.height)
                 if (parentRect.origin.y - screenRect.origin.y > drawerRect.size.height)
                     return NSMinYEdge;
-            
-            return NSMinXEdge;
-            
+
+            return NSMaxYEdge;
+
         default:
             return NSMaxXEdge;
     }


### PR DESCRIPTION
I believe that this function intends to return the preferred edge when compatible with the frames of the parent window and drawer window relative to the screen's visible frame.

However, I have not tested my change nor have I even built the code. (I haven't yet figured out how to build RavynOS on my machine.)