### PR TITLE
explicit bash instead of sh

### DIFF
--- a/Developer/ravynOS.sdk/CMakeLists.txt
+++ b/Developer/ravynOS.sdk/CMakeLists.txt
@@ -44,7 +44,7 @@ execute_process(COMMAND
 set(libc_path ${ROOT_SOURCE_DIR}/Libraries/Libsystem/libsystem_c)
 execute_process(COMMAND env SRCROOT=${libc_path} DSTROOT=${RAVYN_SDKROOT}
     SDK_INSTALL_HEADERS_ROOT=. "PATH=${TOOLS}:$ENV{PATH}" ARCHS="${CpuArch} "
-    VARIANT_PLATFORM_NAME=macosx sh ${libc_path}/xcodescripts/headers.sh
+    VARIANT_PLATFORM_NAME=macosx bash ${libc_path}/xcodescripts/headers.sh
 )
 execute_process(
     COMMAND

--- a/Libraries/Libsystem/libsystem_c/CMakeLists.txt
+++ b/Libraries/Libsystem/libsystem_c/CMakeLists.txt
@@ -1367,7 +1367,7 @@ add_custom_target(generateLinklists
 		BUILD_ARCHIVES="Base FreeBSD TRE vInode32"
 		BUILT_PRODUCTS_DIR=${CMAKE_CURRENT_BINARY_DIR} 
 		DERIVED_FILES_DIR=${CMAKE_CURRENT_BINARY_DIR}
-		sh ${CMAKE_CURRENT_SOURCE_DIR}/xcodescripts/build_linklists.sh
+		bash ${CMAKE_CURRENT_SOURCE_DIR}/xcodescripts/build_linklists.sh
 )
 
 add_dependencies(libsystem_c Platform


### PR DESCRIPTION
sh defaults to dash on Ubuntu Server 25.10