### PR TITLE
Add ARM64 (Apple Silicon) darwin target support

### DIFF
--- a/CoreServices/Makefile
+++ b/CoreServices/Makefile
@@ -9,8 +9,10 @@ clean:
 DMIHelper: ${.CURDIR}/DMIHelper.c
 	mkdir -p ${BUILDROOT}/System/Library/CoreServices
 	$(CC) -o ${BUILDROOT}/System/Library/CoreServices/DMIHelper ${.CURDIR}/DMIHelper.c
+.if !defined(NO_ROOT) || !${NO_ROOT}
 	${SUDO} chown 0:0 ${BUILDROOT}/System/Library/CoreServices/DMIHelper
 	${SUDO} chmod 4755 ${BUILDROOT}/System/Library/CoreServices/DMIHelper
+.endif
 
 build: buildWindowServer DMIHelper buildDock buildFiler
 	mkdir -p ${BUILDROOT}/System/Library/CoreServices/

--- a/Developer/Default.xctoolchain/dtrace_ctf/libctf/qsort.c
+++ b/Developer/Default.xctoolchain/dtrace_ctf/libctf/qsort.c
@@ -173,8 +173,10 @@ loop:
 	}
 }
 
+#if !defined(__APPLE__)
 void
 qsort_r(void *a, size_t n, size_t es, cmp_t *cmp, void *thunk)
 {
 	local_qsort_r(a, n, es, cmp, thunk);
 }
+#endif

--- a/Developer/Default.xctoolchain/include/TargetConditionals.h
+++ b/Developer/Default.xctoolchain/include/TargetConditionals.h
@@ -45,6 +45,7 @@
         TARGET_CPU_68K          - Compiler is generating 680x0 instructions
         TARGET_CPU_X86          - Compiler is generating x86 instructions
         TARGET_CPU_ARM          - Compiler is generating ARM instructions
+        TARGET_CPU_ARM64        - Compiler is generating ARM64 instructions
         TARGET_CPU_MIPS         - Compiler is generating MIPS instructions
         TARGET_CPU_SPARC        - Compiler is generating Sparc instructions
         TARGET_CPU_ALPHA        - Compiler is generating Dec Alpha instructions
@@ -99,6 +100,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0   
         #define TARGET_CPU_ALPHA        0
@@ -119,6 +121,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0   
         #define TARGET_CPU_ALPHA        0
@@ -134,6 +137,7 @@
         #define TARGET_CPU_X86          1
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -149,6 +153,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       1
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -164,6 +169,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          1
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -172,6 +178,22 @@
         #define TARGET_RT_LITTLE_ENDIAN 1
         #define TARGET_RT_BIG_ENDIAN    0
         #define TARGET_RT_64_BIT        0
+     #elif defined(__arm64__) || defined(__aarch64__)
+        #define TARGET_CPU_PPC          0
+        #define TARGET_CPU_PPC64        0
+        #define TARGET_CPU_68K          0
+        #define TARGET_CPU_X86          0
+        #define TARGET_CPU_X86_64       0
+        #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        1
+        #define TARGET_CPU_MIPS         0
+        #define TARGET_CPU_SPARC        0
+        #define TARGET_CPU_ALPHA        0
+        #define TARGET_RT_MAC_CFM       0
+        #define TARGET_RT_MAC_MACHO     1
+        #define TARGET_RT_LITTLE_ENDIAN 1
+        #define TARGET_RT_BIG_ENDIAN    0
+        #define TARGET_RT_64_BIT        1
     #else
         #error unrecognized GNU C compiler
     #endif
@@ -227,6 +249,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -236,6 +259,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -245,6 +269,7 @@
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_68K      0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -254,6 +279,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_68K      0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -263,6 +289,17 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_68K      0
+        #define TARGET_CPU_ARM64    0
+        #define TARGET_CPU_MIPS     0
+        #define TARGET_CPU_SPARC    0
+        #define TARGET_CPU_ALPHA    0
+    #elif defined(TARGET_CPU_ARM64) && TARGET_CPU_ARM64
+        #define TARGET_CPU_PPC      0
+        #define TARGET_CPU_PPC64    0
+        #define TARGET_CPU_X86      0
+        #define TARGET_CPU_X86_64   0
+        #define TARGET_CPU_68K      0
+        #define TARGET_CPU_ARM      0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -287,6 +324,7 @@
         #define TARGET_CPU_68K    0
         #define TARGET_CPU_X86    0
         #define TARGET_CPU_ARM    0
+        #define TARGET_CPU_ARM64  0
         #define TARGET_CPU_MIPS   0
         #define TARGET_CPU_SPARC  0
         #define TARGET_CPU_ALPHA  0
@@ -302,7 +340,7 @@
         #define TARGET_RT_BIG_ENDIAN     0
         #define TARGET_RT_LITTLE_ENDIAN  1
     #endif
-    #if TARGET_CPU_PPC64 || TARGET_CPU_X86_64
+    #if TARGET_CPU_PPC64 || TARGET_CPU_X86_64 || TARGET_CPU_ARM64
         #define TARGET_RT_64_BIT         1
     #else
         #define TARGET_RT_64_BIT         0

--- a/Developer/Default.xctoolchain/include/runtime/TargetConditionals.h
+++ b/Developer/Default.xctoolchain/include/runtime/TargetConditionals.h
@@ -45,6 +45,7 @@
         TARGET_CPU_68K          - Compiler is generating 680x0 instructions
         TARGET_CPU_X86          - Compiler is generating x86 instructions
         TARGET_CPU_ARM          - Compiler is generating ARM instructions
+        TARGET_CPU_ARM64        - Compiler is generating ARM64 instructions
         TARGET_CPU_MIPS         - Compiler is generating MIPS instructions
         TARGET_CPU_SPARC        - Compiler is generating Sparc instructions
         TARGET_CPU_ALPHA        - Compiler is generating Dec Alpha instructions
@@ -99,6 +100,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0   
         #define TARGET_CPU_ALPHA        0
@@ -119,6 +121,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0   
         #define TARGET_CPU_ALPHA        0
@@ -134,6 +137,7 @@
         #define TARGET_CPU_X86          1
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -149,6 +153,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       1
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -164,6 +169,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          1
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -172,6 +178,22 @@
         #define TARGET_RT_LITTLE_ENDIAN 1
         #define TARGET_RT_BIG_ENDIAN    0
         #define TARGET_RT_64_BIT        0
+     #elif defined(__arm64__) || defined(__aarch64__)
+        #define TARGET_CPU_PPC          0
+        #define TARGET_CPU_PPC64        0
+        #define TARGET_CPU_68K          0
+        #define TARGET_CPU_X86          0
+        #define TARGET_CPU_X86_64       0
+        #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        1
+        #define TARGET_CPU_MIPS         0
+        #define TARGET_CPU_SPARC        0
+        #define TARGET_CPU_ALPHA        0
+        #define TARGET_RT_MAC_CFM       0
+        #define TARGET_RT_MAC_MACHO     1
+        #define TARGET_RT_LITTLE_ENDIAN 1
+        #define TARGET_RT_BIG_ENDIAN    0
+        #define TARGET_RT_64_BIT        1
     #else
         #error unrecognized GNU C compiler
     #endif
@@ -227,6 +249,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -236,6 +259,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -245,6 +269,7 @@
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_68K      0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -254,6 +279,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_68K      0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -263,6 +289,17 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_68K      0
+        #define TARGET_CPU_ARM64    0
+        #define TARGET_CPU_MIPS     0
+        #define TARGET_CPU_SPARC    0
+        #define TARGET_CPU_ALPHA    0
+    #elif defined(TARGET_CPU_ARM64) && TARGET_CPU_ARM64
+        #define TARGET_CPU_PPC      0
+        #define TARGET_CPU_PPC64    0
+        #define TARGET_CPU_X86      0
+        #define TARGET_CPU_X86_64   0
+        #define TARGET_CPU_68K      0
+        #define TARGET_CPU_ARM      0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -287,6 +324,7 @@
         #define TARGET_CPU_68K    0
         #define TARGET_CPU_X86    0
         #define TARGET_CPU_ARM    0
+        #define TARGET_CPU_ARM64  0
         #define TARGET_CPU_MIPS   0
         #define TARGET_CPU_SPARC  0
         #define TARGET_CPU_ALPHA  0
@@ -302,7 +340,7 @@
         #define TARGET_RT_BIG_ENDIAN     0
         #define TARGET_RT_LITTLE_ENDIAN  1
     #endif
-    #if TARGET_CPU_PPC64 || TARGET_CPU_X86_64
+    #if TARGET_CPU_PPC64 || TARGET_CPU_X86_64 || TARGET_CPU_ARM64
         #define TARGET_RT_64_BIT         1
     #else
         #define TARGET_RT_64_BIT         0

--- a/Developer/Default.xctoolchain/xar/Makefile
+++ b/Developer/Default.xctoolchain/xar/Makefile
@@ -30,6 +30,9 @@ XAR_OBJS = ${XAR_SRCS:%.c=%.o}
 
 .if "${.MAKE.OS}" == "Linux"
 LDFLAGS += -lacl -lbsd -L/usr/lib/x86_64-linux-gnu
+.elif "${.MAKE.OS}" == "Darwin"
+CFLAGS += -I/opt/homebrew/opt/openssl@3/include -I/usr/local/opt/openssl@3/include
+LDFLAGS += -L/opt/homebrew/opt/openssl@3/lib -L/usr/local/opt/openssl@3/lib
 .endif
 LDFLAGS += -lssl -lcrypto -lxml2 -lz
 LIBS = ${TOOLCHAIN}/usr/lib/libstuff.a ${TOOLCHAIN}/usr/lib/libxar.a

--- a/Developer/ravynOS.sdk/usr/include/TargetConditionals.h
+++ b/Developer/ravynOS.sdk/usr/include/TargetConditionals.h
@@ -45,6 +45,7 @@
         TARGET_CPU_68K          - Compiler is generating 680x0 instructions
         TARGET_CPU_X86          - Compiler is generating x86 instructions
         TARGET_CPU_ARM          - Compiler is generating ARM instructions
+        TARGET_CPU_ARM64        - Compiler is generating ARM64 instructions
         TARGET_CPU_MIPS         - Compiler is generating MIPS instructions
         TARGET_CPU_SPARC        - Compiler is generating Sparc instructions
         TARGET_CPU_ALPHA        - Compiler is generating Dec Alpha instructions
@@ -99,6 +100,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0   
         #define TARGET_CPU_ALPHA        0
@@ -119,6 +121,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0   
         #define TARGET_CPU_ALPHA        0
@@ -134,6 +137,7 @@
         #define TARGET_CPU_X86          1
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -149,6 +153,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       1
         #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -164,6 +169,7 @@
         #define TARGET_CPU_X86          0
         #define TARGET_CPU_X86_64       0
         #define TARGET_CPU_ARM          1
+        #define TARGET_CPU_ARM64        0
         #define TARGET_CPU_MIPS         0
         #define TARGET_CPU_SPARC        0
         #define TARGET_CPU_ALPHA        0
@@ -172,6 +178,22 @@
         #define TARGET_RT_LITTLE_ENDIAN 1
         #define TARGET_RT_BIG_ENDIAN    0
         #define TARGET_RT_64_BIT        0
+     #elif defined(__arm64__) || defined(__aarch64__)
+        #define TARGET_CPU_PPC          0
+        #define TARGET_CPU_PPC64        0
+        #define TARGET_CPU_68K          0
+        #define TARGET_CPU_X86          0
+        #define TARGET_CPU_X86_64       0
+        #define TARGET_CPU_ARM          0
+        #define TARGET_CPU_ARM64        1
+        #define TARGET_CPU_MIPS         0
+        #define TARGET_CPU_SPARC        0
+        #define TARGET_CPU_ALPHA        0
+        #define TARGET_RT_MAC_CFM       0
+        #define TARGET_RT_MAC_MACHO     1
+        #define TARGET_RT_LITTLE_ENDIAN 1
+        #define TARGET_RT_BIG_ENDIAN    0
+        #define TARGET_RT_64_BIT        1
     #else
         #error unrecognized GNU C compiler
     #endif
@@ -227,6 +249,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -236,6 +259,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -245,6 +269,7 @@
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_68K      0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -254,6 +279,7 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_68K      0
         #define TARGET_CPU_ARM      0
+        #define TARGET_CPU_ARM64    0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -263,6 +289,17 @@
         #define TARGET_CPU_X86      0
         #define TARGET_CPU_X86_64   0
         #define TARGET_CPU_68K      0
+        #define TARGET_CPU_ARM64    0
+        #define TARGET_CPU_MIPS     0
+        #define TARGET_CPU_SPARC    0
+        #define TARGET_CPU_ALPHA    0
+    #elif defined(TARGET_CPU_ARM64) && TARGET_CPU_ARM64
+        #define TARGET_CPU_PPC      0
+        #define TARGET_CPU_PPC64    0
+        #define TARGET_CPU_X86      0
+        #define TARGET_CPU_X86_64   0
+        #define TARGET_CPU_68K      0
+        #define TARGET_CPU_ARM      0
         #define TARGET_CPU_MIPS     0
         #define TARGET_CPU_SPARC    0
         #define TARGET_CPU_ALPHA    0
@@ -287,6 +324,7 @@
         #define TARGET_CPU_68K    0
         #define TARGET_CPU_X86    0
         #define TARGET_CPU_ARM    0
+        #define TARGET_CPU_ARM64  0
         #define TARGET_CPU_MIPS   0
         #define TARGET_CPU_SPARC  0
         #define TARGET_CPU_ALPHA  0
@@ -302,7 +340,7 @@
         #define TARGET_RT_BIG_ENDIAN     0
         #define TARGET_RT_LITTLE_ENDIAN  1
     #endif
-    #if TARGET_CPU_PPC64 || TARGET_CPU_X86_64
+    #if TARGET_CPU_PPC64 || TARGET_CPU_X86_64 || TARGET_CPU_ARM64
         #define TARGET_RT_64_BIT         1
     #else
         #define TARGET_RT_64_BIT         0

--- a/Docs/BUILDING.md
+++ b/Docs/BUILDING.md
@@ -24,6 +24,7 @@ __On macOS:__
 * Have a recent Xcode installed
 * Run: `cmake -S /path/to/ravynos -B /path/to/build -GNinja`
 * Run: `cmake --build /path/to/build`
+* Note: For BSD make target builds on macOS hosts without root privileges, use `bmake -j8 NO_ROOT=1 world`.
 
 
 __On Linux (tested on Arch 2025/12/21):__

--- a/Frameworks/CoreFoundation/GNUMakefile
+++ b/Frameworks/CoreFoundation/GNUMakefile
@@ -73,7 +73,9 @@ install: $(OBJBASE)/CoreFoundation_$(STYLE)
 	#/usr/bin/strip -S -o $(DSTBASE)/CoreFoundation.framework/Versions/A/CoreFoundation $(OBJBASE)/CoreFoundation_$(STYLE)
 	/bin/cp $(OBJBASE)/CoreFoundation_$(STYLE) $(DSTBASE)/CoreFoundation.framework/Versions/A/CoreFoundation
 	/usr/bin/dsymutil $(DSTBASE)/CoreFoundation.framework/Versions/A/CoreFoundation -o $(DSTBASE)/CoreFoundation.framework.dSYM
+ifneq ($(NO_ROOT),1)
 	/usr/sbin/chown -RH -f root:wheel $(DSTBASE)/CoreFoundation.framework
+endif
 	/bin/chmod -RH a-w,a+rX $(DSTBASE)/CoreFoundation.framework
 	/bin/chmod -RH u+w $(DSTBASE)
 	install_name_tool -id /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation $(DSTBASE)/CoreFoundation.framework/Versions/A/CoreFoundation


### PR DESCRIPTION
Closes the first ARM64 build blocker on Apple Silicon macOS hosts (issue #575): clang targeting arm64 defines `__aarch64__`/`__arm64__`, neither handled in `TargetConditionals.h`, so every compile falls through to `#error unrecognized GNU C compiler`.

## Changes
- **TargetConditionals.h** (toolchain + runtime + SDK copies): add `TARGET_CPU_ARM64` define, an `__arm64__`/`__aarch64__` branch (64-bit, little-endian), and wire into the `TARGET_RT_64_BIT` chain
- **dtrace_ctf/libctf/qsort.c**: guard `qsort_r` redefinition against macOS libc
- **xar/Makefile**: Darwin Homebrew openssl@3 include/lib paths
- **CoreServices/Makefile** + **CoreFoundation/GNUMakefile**: honor `NO_ROOT` (no `chown root:wheel` on unprivileged host builds)
- **Docs/BUILDING.md**: document `bmake -j8 NO_ROOT=1 world` for macOS hosts

## Verification
`TargetConditionals.h` compiles + runs standalone for `arm64-apple-darwin` (TARGET_CPU_ARM64=1, TARGET_RT_64_BIT=1, little-endian) and `x86_64` (no regression). Produced via the entheai fan-out (agy coders, coder.vaked.dev free tier).